### PR TITLE
Feature add reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ from spark_expectations.config.user_config import *
 
 
 @se.with_expectations(
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table=),
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table=),
     write_to_table=True,
     write_to_temp_table=True,
     row_dq=True,
@@ -123,7 +123,7 @@ from spark_expectations.config.user_config import *
         se_final_query_dq: True,
         se_target_table_view: "order",
     },
-    spark_conf=se_global_spark_Conf,
+    user_conf=se_global_spark_Conf,
 
 )
 def build_new() -> DataFrame:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -118,8 +118,8 @@ from spark_expectations.config.user_config import *  # (7)!
 
 
 @se.with_expectations(  # (6)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table=),
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table=),
     write_to_table=True,  # (4)!
     write_to_temp_table=True,  # (8)!
     row_dq=True,  # (9)!
@@ -134,7 +134,7 @@ from spark_expectations.config.user_config import *  # (7)!
         user_config.se_final_query_dq: True,  # (17)!
         user_config.se_target_table_view: "order",  # (18)!
     },
-    spark_conf=se_global_spark_Conf,  # (19)!
+    user_conf=se_global_spark_Conf,  # (19)!
 
 )
 def build_new() -> DataFrame:
@@ -203,8 +203,8 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(  # (1)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order")
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order")
 )
 
 ,
@@ -227,8 +227,8 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(  # (1)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order"),
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order"),
     row_dq=False,  # (2)!
     agg_dq={
         user_config.se_agg_dq: True,
@@ -254,8 +254,8 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(  # (1)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order"),
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order"),
     row_dq=True,
     query_dq={  # (2)!
         user_config.se_query_dq: True,
@@ -298,8 +298,8 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(  # (1)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order"),
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order"),
     row_dq=True,
     agg_dq={  # (10)!
         user_config.user_configse_agg_dq: True,
@@ -329,9 +329,9 @@ import os
 
 
 @se.with_expectations(
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order"),
-    spark_conf=se_global_spark_Conf,  # (2)!
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order"),
+    user_conf=se_global_spark_Conf,  # (2)!
 
 )
 def build_new() -> DataFrame:
@@ -353,8 +353,8 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(  # (1)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order"),
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order"),
     row_dq=False,
     agg_dq={
         user_config.se_agg_dq: False,
@@ -385,8 +385,8 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(  # (1)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order", actions_if_failed=["drop", "ignore"])
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order", actions_if_failed=["drop", "ignore"])
 )
 def build_new() -> DataFrame:
     _df_order: DataFrame = (
@@ -405,8 +405,8 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(  # (1)!
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order", actions_if_failed=["drop", "ignore"]),
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order", actions_if_failed=["drop", "ignore"]),
     row_dq=True,  # (2)!
     agg_dq={
         user_config.se_agg_dq: True,
@@ -458,9 +458,9 @@ def build_new() -> DataFrame:
 
 ```python
 @se.with_expectations(
-    se.reader.get_rules_from_table(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
-                                   target_table="pilot_nonpub.customer_order"),
-    spark_conf={"spark.files.maxPartitionBytes": "134217728"},  # (1)!
+    se.reader.get_rules_from_df(rules_table="pilot_nonpub.dq.dq_rules", dq_stats_table="pilot_nonpub.dq.dq_stats",
+                                target_table="pilot_nonpub.customer_order"),
+    user_conf={"spark.files.maxPartitionBytes": "134217728"},  # (1)!
     options={"mode": "overwrite", "partitionBy": "order_month",
              "overwriteSchema": "true"},  # (2)!
     options_error_table={"partition_by": "id"}  # (3)!

--- a/spark_expectations/core/__init__.py
+++ b/spark_expectations/core/__init__.py
@@ -32,4 +32,4 @@ def get_spark_session() -> SparkSession:
         )
         return configure_spark_with_delta_pip(builder).getOrCreate()
 
-    return SparkSession.builder.getOrCreate()
+    return SparkSession.getActiveSession()

--- a/spark_expectations/core/context.py
+++ b/spark_expectations/core/context.py
@@ -5,8 +5,7 @@ from datetime import datetime
 from dataclasses import dataclass
 from uuid import uuid1
 from typing import Dict, Optional, List
-from pyspark.sql import DataFrame
-from spark_expectations.core import get_spark_session
+from pyspark.sql import DataFrame, SparkSession
 from spark_expectations.config.user_config import Constants as user_config
 from spark_expectations.core.exceptions import SparkExpectationsMiscException
 
@@ -20,9 +19,9 @@ class SparkExpectationsContext:
     """
 
     product_id: str
+    spark: SparkSession
 
     def __post_init__(self) -> None:
-        self.spark = get_spark_session()
         self._run_id: str = f"{self.product_id}_{uuid1()}"
         self._run_date: str = self.set_run_date()
         self._dq_stats_table_name: Optional[str] = None

--- a/spark_expectations/core/expectations.py
+++ b/spark_expectations/core/expectations.py
@@ -31,14 +31,15 @@ class SparkExpectations:
 
     Args:
         product_id: Name of the product
-        rules_table: Name of the table which contains the rules
+        rules_df: DataFrame which contains the rules. User is responsible for reading
+            the rules_table in which ever system it is
         stats_table: Name of the table where the stats/audit-info need to be written
         debugger: Mark it as "True" if the debugger mode need to be enabled, by default is False
         stats_streaming_options: Provide options to override the defaults, while writing into the stats streaming table
     """
 
     product_id: str
-    rules_table: str
+    rules_df: DataFrame
     stats_table: str
     target_and_error_table_writer: Type["WrappedDataFrameWriter"]
     stats_table_writer: Type["WrappedDataFrameWriter"]
@@ -73,6 +74,8 @@ class SparkExpectations:
         )
         self._context.set_stats_table_writer_config(self.stats_table_writer.build())
         self._context.set_debugger_mode(self.debugger)
+        self._context.set_dq_stats_table_name(self.stats_table)
+        self.rules_df = self.rules_df.cache()
 
     # TODO Add target_error_table_writer and stats_table_writer as parameters to this function so this takes precedence
     #  if user provides it
@@ -81,13 +84,9 @@ class SparkExpectations:
         target_table: str,
         write_to_table: bool = False,
         write_to_temp_table: bool = False,
-        spark_conf: Optional[Dict[str, Union[str, int, bool]]] = None,
-        rules_table: Optional[str] = None,
-        stats_table: Optional[str] = None,
+        user_conf: Optional[Dict[str, Union[str, int, bool]]] = None,
         target_table_view: Optional[str] = None,
-        actions_if_failed: Optional[List[str]] = None,
         target_and_error_table_writer: Optional[Type["WrappedDataFrameWriter"]] = None,
-        stats_table_writer: Optional[Type["WrappedDataFrameWriter"]] = None,
     ) -> Any:
         """
         This decorator helps to wrap a function which returns dataframe and apply dataframe rules on it
@@ -97,16 +96,10 @@ class SparkExpectations:
             write_to_table: Mark it as "True" if the dataframe need to be written as table
             write_to_temp_table: Mark it as "True" if the input dataframe need to be written to the temp table to break
                                 the spark plan
-            spark_conf: Provide options to override the defaults, while writing into the stats streaming table
-            rules_table: Name of the table which contains the rules
-            stats_table: Name of the table where the stats/audit-info need to be written
+            user_conf: Provide options to override the defaults, while writing into the stats streaming table
             target_table_view: This view is created after the _row_dq process to run the target agg_dq and query_dq.
                 If value is not provided, defaulted to {target_table}_view
-            actions_if_failed: Provide the list of actions to be taken if the expectations failed. Default would be all
-                actions ['ignore', 'drop', 'fail']
             target_and_error_table_writer: Provide the writer to write the target and error table,
-                this will take precedence over the class level writer
-            stats_table_writer: Provide the writer to write the stats table,
                 this will take precedence over the class level writer
 
         Returns:
@@ -115,6 +108,7 @@ class SparkExpectations:
 
         def _except(func: Any) -> Any:
             # variable used for enabling notification at different level
+
             _default_notification_dict: Dict[str, Union[str, int, bool]] = {
                 user_config.se_notifications_on_start: False,
                 user_config.se_notifications_on_completion: False,
@@ -123,11 +117,10 @@ class SparkExpectations:
                 user_config.se_notifications_on_error_drop_threshold: 100,
             }
             _notification_dict: Dict[str, Union[str, int, bool]] = (
-                {**_default_notification_dict, **spark_conf}
-                if spark_conf
+                {**_default_notification_dict, **user_conf}
+                if user_conf
                 else _default_notification_dict
             )
-
             _default_stats_streaming_dict: Dict[str, Union[bool, str]] = {
                 user_config.se_enable_streaming: True,
                 user_config.secret_type: "databricks",
@@ -139,7 +132,6 @@ class SparkExpectations:
                 user_config.dbx_secret_token: "se_streaming_auth_secret_token_key",
                 user_config.dbx_topic_name: "se_streaming_topic_name",
             }
-
             _se_stats_streaming_dict: Dict[str, Any] = (
                 {**self.stats_streaming_options}
                 if self.stats_streaming_options
@@ -151,15 +143,10 @@ class SparkExpectations:
                 self._context.set_target_and_error_table_writer_config(
                     target_and_error_table_writer.build()
                 )
-            if stats_table_writer:
-                self._context.set_stats_table_writer_config(stats_table_writer.build())
 
             # need to call the get_rules_frm_table function to get the rules from the table as expectations
-            expectations, rules_execution_settings = self.reader.get_rules_from_table(
-                self.rules_table if rules_table is None else rules_table,
-                self.stats_table if stats_table is None else stats_table,
-                target_table,
-                actions_if_failed,
+            expectations, rules_execution_settings = self.reader.get_rules_from_df(
+                self.rules_table, target_table
             )
 
             _row_dq: bool = rules_execution_settings.get("row_dq", False)
@@ -228,7 +215,7 @@ class SparkExpectations:
                 else 100
             )
 
-            self.reader.set_notification_param(spark_conf)
+            self.reader.set_notification_param(user_conf)
             self._context.set_notification_on_start(_notification_on_start)
             self._context.set_notification_on_completion(_notification_on_completion)
             self._context.set_notification_on_fail(_notification_on_fail)

--- a/spark_expectations/examples/base_setup.py
+++ b/spark_expectations/examples/base_setup.py
@@ -1,37 +1,11 @@
 import os
-import subprocess
+from pyspark.sql.session import SparkSession
 
-# setting up env for local
 os.environ["SPARKEXPECTATIONS_ENV"] = "local"
 
-from spark_expectations.core import get_spark_session
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
-spark = get_spark_session()
-
-
-def main() -> None:
-    os.environ["DQ_SPARK_EXPECTATIONS_CERBERUS_TOKEN"] = ""
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-
-    print("Creating the necessary infrastructure for the tests to run locally!")
-
-    # run kafka locally in docker
-    print("create or run if exist docker container")
-    os.system(f"sh {current_dir}/docker_scripts/docker_kafka_start_script.sh")
-
-    # create database
-    os.system("rm -rf /tmp/hive/warehouse/dq_spark_local.db")
-    spark.sql("create database if not exists dq_spark_local")
-    spark.sql("use dq_spark_local")
-
-    # create project_rules_table
-    spark.sql("drop table if exists dq_rules")
-    os.system("rm -rf /tmp/hive/warehouse/dq_spark_local.db/dq_rules")
-
-    spark.sql(
-        """
-    create table dq_rules (
-    product_id STRING,
+RULES_TABLE_SCHEMA = """ ( product_id STRING,
     table_name STRING,
     rule_type STRING,
     rule STRING,
@@ -44,54 +18,10 @@ def main() -> None:
     enable_for_target_dq_validation BOOLEAN,
     is_active BOOLEAN,
     enable_error_drop_alert BOOLEAN,
-    error_drop_threshold INT
-    )
-    USING delta
-    """
-    )
+    error_drop_threshold INT )
+"""
 
-    spark.sql(
-        "ALTER TABLE dq_rules ADD CONSTRAINT rule_type_action CHECK (rule_type in ('row_dq', 'agg_dq', 'query_dq'));"
-    )
-
-    spark.sql(
-        "ALTER TABLE dq_rules ADD CONSTRAINT action CHECK ((rule_type = 'row_dq' and action_if_failed IN ('ignore', 'drop', 'fail')) or "
-        "(rule_type = 'agg_dq' and action_if_failed in ('ignore', 'fail')) or (rule_type = 'query_dq' and action_if_failed in ('ignore', 'fail')));"
-    )
-
-    # create project_dq_stats_table
-    # spark.sql("drop table if exists dq_stats")
-    # os.system("rm -rf /tmp/hive/warehouse/dq_spark_local.db/dq_stats")
-    # spark.sql(
-    #     """
-    # create table dq_stats (
-    # product_id STRING,
-    # table_name STRING,
-    # input_count LONG,
-    # error_count LONG,
-    # output_count LONG,
-    # output_percentage FLOAT,
-    # success_percentage FLOAT,
-    # error_percentage FLOAT,
-    # source_agg_dq_results array<map<string, string>>,
-    # final_agg_dq_results array<map<string, string>>,
-    # source_query_dq_results array<map<string, string>>,
-    # final_query_dq_results array<map<string, string>>,
-    # row_dq_res_summary array<map<string, string>>,
-    # dq_status map<string, string>,
-    # dq_run_time map<string, float>,
-    # dq_rules map<string, map<string,int>>,
-    # meta_dq_run_id STRING,
-    # meta_dq_run_date DATE,
-    # meta_dq_run_datetime TIMESTAMP
-    # )
-    # USING delta
-    # """
-    # )
-
-    spark.sql(
-        """
-    insert into table dq_rules values
+RULES_DATA = """ 
     ("your_product", "dq_spark_local.customer_order",  "row_dq", "customer_id_is_not_null", "customer_id", "customer_id is not null","drop", "validity", "customer_id ishould not be null", true, true,false, false, 0)
     ,("your_product", "dq_spark_local.customer_order", "row_dq", "sales_greater_than_zero", "sales", "sales > 0", "drop", "accuracy", "sales value should be greater than zero", true, true, false, false, 0)
     ,("your_product", "dq_spark_local.customer_order", "row_dq", "discount_threshold", "discount", "discount*100 < 60","drop", "validity", "discount should be less than 40", true, true, false, false, 0)
@@ -106,61 +36,96 @@ def main() -> None:
     ,("your_product", "dq_spark_local.customer_order", "query_dq", "product_missing_count_threshold", "*", "((select count(distinct product_id) from product) - (select count(distinct product_id) from order))>(select count(distinct product_id) from product)*0.2", "ignore", "validity", "row count threshold", true, true, true, false, 0)
     ,("your_product", "dq_spark_local.customer_order", "query_dq", "product_category", "*", "(select count(distinct category) from product) < 5", "ignore", "validity", "distinct product category", true, true, true, false, 0)
     ,("your_product", "dq_spark_local.customer_order", "query_dq", "row_count_in_order", "*", "(select count(*) from order)<10000", "ignore", "accuracy", "count of the row in order dataset", true, true, true, false, 0)
-     """
+    
+"""
+
+
+def set_up_kafka():
+    print("create or run if exist docker container")
+    os.system(f"sh {CURRENT_DIR}/docker_scripts/docker_kafka_start_script.sh")
+
+
+def add_kafka_jars(builder):
+    return builder.config(  # below jars are used only in the local env, not coupled with databricks or EMR
+        "spark.jars",
+        f"{CURRENT_DIR}/../../jars/spark-sql-kafka-0-10_2.12-3.0.0.jar,"
+        f"{CURRENT_DIR}/../../jars/kafka-clients-3.0.0.jar,"
+        f"{CURRENT_DIR}/../../jars/commons-pool2-2.8.0.jar,"
+        f"{CURRENT_DIR}/../../jars/spark-token-provider-kafka-0-10_2.12-3.0.0.jar")
+
+
+def set_up_iceberg():
+    set_up_kafka()
+    spark = add_kafka_jars(SparkSession.builder \
+        .config('spark.jars.packages', 'org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:1.3.1') \
+        .config('spark.sql.extensions', 'org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions') \
+        .config('spark.sql.catalog.spark_catalog', 'org.apache.iceberg.spark.SparkSessionCatalog') \
+        .config('spark.sql.catalog.spark_catalog.type','hadoop') \
+        .config('spark.sql.catalog.spark_catalog.warehouse', '/tmp/hive/warehouse')
+        .config('spark.sql.catalog.local', 'org.apache.iceberg.spark.SparkCatalog') \
+        .config('spark.sql.catalog.local.type', 'hadoop') \
+        .config('spark.sql.catalog.local.warehouse', '/tmp/hive/warehouse')).getOrCreate()
+
+    os.system("rm -rf /tmp/hive/warehouse/dq_spark_local")
+
+    spark.sql("create database if not exists spark_catalog.dq_spark_local")
+    spark.sql(" use spark_catalog.dq_spark_local")
+
+    spark.sql("drop table if exists dq_spark_local.dq_stats")
+
+    spark.sql("drop table if exists dq_spark_local.dq_rules")
+
+    spark.sql(f" CREATE TABLE dq_spark_local.dq_rules {RULES_TABLE_SCHEMA} USING ICEBERG")
+    spark.sql(f" INSERT INTO dq_spark_local.dq_rules  values {RULES_DATA} ")
+
+    spark.sql("select * from dq_spark_local.dq_rules").show(truncate=False)
+    return spark
+
+
+def set_up_bigquery(materialization_dataset):
+
+    set_up_kafka()
+    spark = add_kafka_jars(SparkSession. \
+        builder \
+        .config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.30.0")). \
+        getOrCreate()
+    spark._jsc.hadoopConfiguration().set('fs.gs.impl', 'com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem')
+    spark.conf.set("viewsEnabled", "true")
+    spark.conf.set("materializationDataset", materialization_dataset)
+
+    # Add dependencies like gcs-connector-hadoop3-2.2.6-SNAPSHOT-shaded.jar, spark-avro_2.12-3.4.1.jar if you wanted to use indirect method for reading/writing
+    return spark
+
+def set_up_delta():
+
+    set_up_kafka()
+    from delta import configure_spark_with_delta_pip
+
+    builder = (
+        add_kafka_jars(SparkSession.builder.config(
+            "spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension"
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .config("spark.sql.warehouse.dir", "/tmp/hive/warehouse")
+        .config("spark.driver.extraJavaOptions", "-Dderby.system.home=/tmp/derby")
+        .config("spark.jars.ivy", "/tmp/ivy2"))
     )
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
 
-    # , ("your_product", "dq_spark_local.customer_order", "row_dq", "referential_integrity_customer_id", "customer_id",
-    #    "customer_id in(select distinct customer_id from customer)", true, true, "drop", true, "validity",
-    #    "referential integrity for cuatomer_id")
-    # , ("your_product", "dq_spark_local.customer_order", "row_dq", "referential_integrity_product_id", "product_id",
-    #    "select count(*) from (select distinct product_id as ref_product from product) where product_id=ref_product > 1",
-    #    true, true, "drop", true, "validity", "referntial integrity for product_id")
-    # , (
-    # "your_product", "dq_spark_local.customer_order", "row_dq", "regex_format_sales", "sales", "sales rlike '[1-9]+.[1-9]+'",
-    # true, true, "drop", true, "validity", "regex format validation for sales")
-    # , ("your_product", "dq_spark_local.customer_order", "row_dq", "regex_format_quantity", "quantity",
-    #    "quantity rlike '[1-9]+.[1-9]+'", true, true, "drop", true, "validity", "regex format validation for quantity")
-    # , ("your_product", "dq_spark_local.customer_order", "row_dq", "date_format_order_date", "order_date",
-    #    "order_date rlike '([1-3][1-9]|[0-1])/([1-2]|[1-9])/20[0-2][0-9]''", true, true, "drop", true, "validity",
-    #    "regex format validation for quantity")
-    # , ("your_product", "dq_spark_local.customer_order", "row_dq", "regex_format_order_id", "order_id",
-    #    "order_id rlike '(US|CA)-20[0-2][0-9]-*''", true, true, "drop", true, "validity",
-    #    "regex format validation for quantity")
+    os.system("rm -rf /tmp/hive/warehouse/dq_spark_local.db")
 
-    # , ("your_product", "dq_spark_local.employee_new", "query_dq", "", "*",
-    #    "(select count(*) from dq_spark_local_employee_new)!=(select count(*) from dq_spark_local_employee_new)", true,
-    #    false, "ignore", false, "validity", "canary check to comapre the two table count")
-    # , ("your_product", "dq_spark_local.employee_new", "query_dq", "department_salary_threshold", "department",
-    #    "(select count(*) from (select department from dq_spark_local_employee_new group by department having sum(bonus)>1000))<1",
-    #    true, false, "ignore", true, "validity", "each sub-department threshold")
-    # , (
-    # "your_product", "dq_spark_local.employee_new", "query_dq", "count_of_exit_date_nulls_threshold", "exit_date", "", true,
-    # true, "ignore", false, "validity", "exit_date null threshold")
+    spark.sql("create database if not exists dq_spark_local")
+    spark.sql("use dq_spark_local")
 
-    # , ("your_product", "dq_spark_local.customer_order", "row_dq", "complete_duplicate", "*",
-    #    "count(*) over(partition by customer_id,product_id,order_id,order_date,ship_date,ship_mode,sales,quantity,discount,profit order by 1)",
-    #    true, true, "drop", true, "validity", "complete duplicate record")
-    # , ("your_product", "dq_spark_local.customer_order", "row_dq", "primary_key_check", "*",
-    #    "count(*) over(partition by customer_id, order_id order by 1)", true, true, "drop", true, "validity",
-    #    "primary key check")
+    spark.sql("drop table if exists dq_stats")
 
-    # ,("your_product", "dq_spark_local.customer_order", "row_dq", "order_date_format_check", "order_date", "to_date(order_date, 'dd/MM/yyyy')", true, true,"drop" ,true, "validity", "Age of the employee should be less than 65")
+    spark.sql("drop table if exists dq_rules")
+
+    spark.sql(f" CREATE TABLE dq_rules {RULES_TABLE_SCHEMA} USING DELTA")
+    spark.sql(f" INSERT INTO dq_rules  values {RULES_DATA} ")
 
     spark.sql("select * from dq_rules").show(truncate=False)
-
-    # DROP the data tables and error tables
-    spark.sql("drop table if exists dq_spark_local.customer_order")
-    os.system(
-        "rm -rf /tmp/hive/warehouse/dq_spark_local.db/dq_spark_local.customer_order"
-    )
-
-    spark.sql("drop table if exists dq_spark_local.customer_order_error")
-    os.system(
-        "rm -rf /tmp/hive/warehouse/dq_spark_local.db/dq_spark_local.customer_order_error"
-    )
-
-    print("Local infrastructure setup is done")
-
-
-if __name__ == "__main__":
-    main()
+    return spark

--- a/spark_expectations/examples/sample_dq_bigquery.py
+++ b/spark_expectations/examples/sample_dq_bigquery.py
@@ -1,0 +1,109 @@
+# mypy: ignore-errors
+import os
+from pyspark.sql import DataFrame
+from spark_expectations import _log
+from spark_expectations.core.expectations import (
+    SparkExpectations,
+    WrappedDataFrameWriter,
+)
+from spark_expectations.config.user_config import Constants as user_config
+from spark_expectations.examples.base_setup import set_up_bigquery
+
+
+writer = WrappedDataFrameWriter.mode("overwrite").format("bigquery").\
+    option("createDisposition", "CREATE_IF_NEEDED")\
+    .option("writeMethod", "direct")
+
+
+# if wanted to use indirect method use below setting and spark session
+# writer = WrappedDataFrameWriter.mode("overwrite").format("bigquery").\
+#     option("createDisposition", "CREATE_IF_NEEDED")\
+#     .option("writeMethod", "indirect")\
+#     .option("intermediateFormat", "AVRO")\
+#     .option("temporaryGcsBucket", "<temporaryGCSBucket>")
+
+
+# pass materialization dataset
+spark = set_up_bigquery("<temp_dataset>")
+
+se: SparkExpectations = SparkExpectations(
+    product_id="your_product",
+    rules_df=spark.read.format("bigquery").load("<project_id>.<dataset_id>.<rules_table>"),
+    stats_table="<project_id>.<dataset_id>.<rules_table>",
+    stats_table_writer=writer,
+    target_and_error_table_writer=writer,
+    debugger=False,
+)
+
+global_spark_Conf = {
+    user_config.se_notifications_enable_email: False,
+    user_config.se_notifications_email_smtp_host: "mailhost.com",
+    user_config.se_notifications_email_smtp_port: 25,
+    user_config.se_notifications_email_from: "",
+    user_config.se_notifications_email_to_other_mail_id: "",
+    user_config.se_notifications_email_subject: "spark expectations - data quality - notifications",
+    user_config.se_notifications_enable_slack: False,
+    user_config.se_notifications_slack_webhook_url: "",
+    user_config.se_notifications_on_start: True,
+    user_config.se_notifications_on_completion: True,
+    user_config.se_notifications_on_fail: True,
+    user_config.se_notifications_on_error_drop_exceeds_threshold_breach: True,
+    user_config.se_notifications_on_error_drop_threshold: 15,
+}
+
+
+@se.with_expectations(
+    target_table="<project_id>.<dataset_id>.<target_table_name>",
+    write_to_table=True,
+    user_conf=global_spark_Conf,
+    target_table_view="<project_id>.<dataset_id>.<target_table_view_name>",
+)
+def build_new() -> DataFrame:
+    _df_order: DataFrame = (
+        spark.read.option("header", "true")
+        .option("inferSchema", "true")
+        .csv(os.path.join(os.path.dirname(__file__), "resources/order.csv"))
+    )
+    _df_order.createOrReplaceTempView("order")
+
+    _df_product: DataFrame = (
+        spark.read.option("header", "true")
+        .option("inferSchema", "true")
+        .csv(os.path.join(os.path.dirname(__file__), "resources/product.csv"))
+    )
+    _df_product.createOrReplaceTempView("product")
+
+    _df_customer: DataFrame = (
+        spark.read.option("header", "true")
+        .option("inferSchema", "true")
+        .csv(os.path.join(os.path.dirname(__file__), "resources/customer.csv"))
+    )
+
+    _df_customer.createOrReplaceTempView("customer")
+
+    return _df_order
+
+
+if __name__ == "__main__":
+    build_new()
+
+    spark.sql("select * from dq_spark_local.dq_stats").show(truncate=False)
+    spark.sql("select * from dq_spark_local.dq_stats").printSchema()
+
+    _log.info("stats data in the kafka topic")
+    # display posted statistics from the kafka topic
+    spark.read.format("kafka").option(
+        "kafka.bootstrap.servers", "localhost:9092"
+    ).option("subscribe", "dq-sparkexpectations-stats").option(
+        "startingOffsets", "earliest"
+    ).option(
+        "endingOffsets", "latest"
+    ).load().selectExpr(
+        "cast(value as string) as stats_records"
+    ).show(
+        truncate=False
+    )
+
+    # remove docker container
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    os.system(f"sh {current_dir}/docker_scripts/docker_kafka_stop_script.sh")

--- a/spark_expectations/examples/sample_dq_delta.py
+++ b/spark_expectations/examples/sample_dq_delta.py
@@ -1,0 +1,99 @@
+# mypy: ignore-errors
+import os
+
+from pyspark.sql import DataFrame
+from spark_expectations import _log
+from spark_expectations.examples.base_setup import set_up_delta
+from spark_expectations.core.expectations import (
+    SparkExpectations,
+    WrappedDataFrameWriter,
+)
+from spark_expectations.config.user_config import Constants as user_config
+
+
+writer = WrappedDataFrameWriter.mode("append").format("delta")
+
+spark = set_up_delta()
+
+se: SparkExpectations = SparkExpectations(
+    product_id="your_product",
+    rules_df=spark.table("dq_spark_local.dq_rules"),
+    stats_table="dq_spark_local.dq_stats",
+    stats_table_writer=writer,
+    target_and_error_table_writer=writer,
+    debugger=False,
+)
+
+
+global_spark_Conf = {
+    user_config.se_notifications_enable_email: False,
+    user_config.se_notifications_email_smtp_host: "mailhost.com",
+    user_config.se_notifications_email_smtp_port: 25,
+    user_config.se_notifications_email_from: "",
+    user_config.se_notifications_email_to_other_mail_id: "",
+    user_config.se_notifications_email_subject: "spark expectations - data quality - notifications",
+    user_config.se_notifications_enable_slack: False,
+    user_config.se_notifications_slack_webhook_url: "",
+    user_config.se_notifications_on_start: True,
+    user_config.se_notifications_on_completion: True,
+    user_config.se_notifications_on_fail: True,
+    user_config.se_notifications_on_error_drop_exceeds_threshold_breach: True,
+    user_config.se_notifications_on_error_drop_threshold: 15,
+}
+
+
+@se.with_expectations(
+    target_table="dq_spark_local.customer_order",
+    write_to_table=True,
+    user_conf=global_spark_Conf,
+    target_table_view="order",
+)
+def build_new() -> DataFrame:
+    _df_order: DataFrame = (
+        spark.read.option("header", "true")
+        .option("inferSchema", "true")
+        .csv(os.path.join(os.path.dirname(__file__), "resources/order.csv"))
+    )
+    _df_order.createOrReplaceTempView("order")
+
+    _df_product: DataFrame = (
+        spark.read.option("header", "true")
+        .option("inferSchema", "true")
+        .csv(os.path.join(os.path.dirname(__file__), "resources/product.csv"))
+    )
+    _df_product.createOrReplaceTempView("product")
+
+    _df_customer: DataFrame = (
+        spark.read.option("header", "true")
+        .option("inferSchema", "true")
+        .csv(os.path.join(os.path.dirname(__file__), "resources/customer.csv"))
+    )
+
+    _df_customer.createOrReplaceTempView("customer")
+
+    return _df_order
+
+
+if __name__ == "__main__":
+    build_new()
+
+    spark.sql("select * from dq_spark_local.dq_stats").show(truncate=False)
+    spark.sql("select * from dq_spark_local.dq_stats").printSchema()
+
+    _log.info("stats data in the kafka topic")
+    # display posted statistics from the kafka topic
+    spark.read.format("kafka").option(
+        "kafka.bootstrap.servers", "localhost:9092"
+    ).option("subscribe", "dq-sparkexpectations-stats").option(
+        "startingOffsets", "earliest"
+    ).option(
+        "endingOffsets", "latest"
+    ).load().selectExpr(
+        "cast(value as string) as stats_records"
+    ).show(
+        truncate=False
+    )
+
+    # remove docker container
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    os.system(f"sh {current_dir}/docker_scripts/docker_kafka_stop_script.sh")

--- a/spark_expectations/secrets/__init__.py
+++ b/spark_expectations/secrets/__init__.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict
 import pluggy
 from spark_expectations.config.user_config import Constants as UserConfig
-from spark_expectations.core import get_spark_session
+from pyspark.sql.session import SparkSession
 from spark_expectations import _log
 
 
@@ -91,9 +91,7 @@ class DatabricksSecretsSparkExpectationsSecretPluginImpl(
         if secret_dict[UserConfig.secret_type].lower() == "databricks":
             try:
                 from pyspark.dbutils import DBUtils
-
-                spark = get_spark_session()  # pragma: no cover
-
+                spark = SparkSession.getActiveSession()
                 dbutils = DBUtils(spark)  # pragma: no cover
             except ImportError:
                 raise ImportError(

--- a/spark_expectations/utils/reader.py
+++ b/spark_expectations/utils/reader.py
@@ -4,9 +4,7 @@ from dataclasses import dataclass
 
 # from cerberus.client import CerberusClient
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import (
-    col,
-)
+from pyspark.sql.functions import col, lit
 from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.config.user_config import Constants as user_config
 from spark_expectations.core import get_spark_session
@@ -124,64 +122,21 @@ class SparkExpectationsReader:
                 f"error occurred while reading notification configurations {e}"
             )
 
-    def get_rules_dlt(
+    def get_rules_from_df(
         self,
-        product_rules_table: str,
-        table_name: str,
-        action: Union[list, str],
-        tag: Optional[str] = None,
-    ) -> dict:
-        """
-        This function supports creating a dict of expectations that is acceptable by DLT
-        Args:
-             product_rules_table: Provide the full table name, which has your data quality rules
-             table_name: Provide the full table name for which the data quality rules are being run
-             action: Provide the action which you want to filter from rules table. Value should only from one of these
-                           - "fail" or "drop" or "ignore" or provide the needed in a list ["fail", "drop", "ignore"]
-             tag: Provide the KPI for which you are running the data quality rule
-
-             Returns:
-                   dict: returns a dict with key as 'rule' and 'expectation' as value
-        """
-        try:
-            _actions: List[str] = [].append(action) if isinstance(action, str) else action  # type: ignore
-            _expectations: dict = {}
-            _rules_df: DataFrame = self.spark.sql(
-                f"""
-                                       select rule, tag, expectation from {product_rules_table} 
-                                       where product_id='{self.product_id}' and table_name='{table_name}' and 
-                                       action_if_failed in ('{"', '".join(_actions)}')
-                                       """
-            )
-            if tag:
-                for row in _rules_df.filter(col("tag") == tag).collect():
-                    _expectations[row["rule"]] = row["expectation"]
-            else:
-                for row in _rules_df.collect():
-                    _expectations[row["rule"]] = row["expectation"]
-            return _expectations
-
-        except Exception as e:
-            raise SparkExpectationsUserInputOrConfigInvalidException(
-                f"error occurred while reading or getting rules from the rules table {e}"
-            )
-
-    def get_rules_from_table(
-        self,
-        rules_table: str,
-        dq_stats_table: str,
+        rules_df: DataFrame,
         target_table: str,
-        actions_if_failed: Optional[List[str]] = None,
+        is_dlt: bool = False,
+        tag: Optional[str] = None,
     ) -> tuple[dict, dict]:
         """
         This function fetches the data quality rules from the table and return it as a dictionary
 
         Args:
-            rules_table: Provide the full table name, which has your data quality rules
+            rules_df: DataFrame which has your data quality rules
             target_table: Provide the full table name for which the data quality rules are being run
-            dq_stats_table: Provide the table name, to which Data Quality Stats have to be written to
-            actions_if_failed: Provide the list of actions in ["fail", "drop", 'ignore'], which need to be applied on a
-                particular row if a rule failed
+            is_dlt: True if this for fetching the rules for dlt job
+            tag: If is_dlt is True, provide the KPI for which you are running the data quality rule
 
         Returns:
             tuple: returns a tuple of two dictionaries with key as 'rule_type' and 'rules_table_row' as value in
@@ -189,8 +144,6 @@ class SparkExpectationsReader:
                     dict
         """
         try:
-            self._context.set_dq_stats_table_name(dq_stats_table)
-
             self._context.set_final_table_name(target_table)
             self._context.set_error_table_name(f"{target_table}_error")
             self._context.set_table_name(target_table)
@@ -201,68 +154,68 @@ class SparkExpectationsReader:
             self._context.reset_num_row_dq_rules()
             self._context.reset_num_query_dq_rules()
 
-            _actions_if_failed: List[str] = actions_if_failed or [
-                "fail",
-                "drop",
-                "ignore",
-            ]
-
-            _rules_df: DataFrame = self.spark.sql(
-                f"""
-                        select * from {rules_table} where product_id='{self.product_id}' 
-                        and table_name='{target_table}'
-                        and action_if_failed in ('{"', '".join(_actions_if_failed)}') and is_active=true
-                        """
+            _rules_df = rules_df.filter(
+                (rules_df["product_id"] == self._context.product_id)
+                & (rules_df["table_name"] == target_table)
+                & (rules_df["is_active"])
             )
-            _rules_df.createOrReplaceTempView("rules")
+
             self._context.print_dataframe_with_debugger(_rules_df)
 
             _expectations: dict = {}
             _rules_execution_settings: dict = {}
-            for row in _rules_df.collect():
-                column_map = {
-                    "product_id": row["product_id"],
-                    "table_name": row["table_name"],
-                    "rule_type": row["rule_type"],
-                    "rule": row["rule"],
-                    "column_name": row["column_name"],
-                    "expectation": row["expectation"],
-                    "action_if_failed": row["action_if_failed"],
-                    "enable_for_source_dq_validation": row[
-                        "enable_for_source_dq_validation"
-                    ],
-                    "enable_for_target_dq_validation": row[
-                        "enable_for_target_dq_validation"
-                    ],
-                    "tag": row["tag"],
-                    "description": row["description"],
-                    "enable_error_drop_alert": row["enable_error_drop_alert"],
-                    "error_drop_threshold": row["error_drop_threshold"],
-                }
-
-                if f"{row['rule_type']}_rules" in _expectations:
-                    _expectations[f"{row['rule_type']}_rules"].append(column_map)
+            if is_dlt:
+                if tag:
+                    for row in _rules_df.filter(col("tag") == tag).collect():
+                        _expectations[row["rule"]] = row["expectation"]
                 else:
-                    _expectations[f"{row['rule_type']}_rules"] = [column_map]
+                    for row in _rules_df.collect():
+                        _expectations[row["rule"]] = row["expectation"]
+            else:
+                for row in _rules_df.collect():
+                    column_map = {
+                        "product_id": row["product_id"],
+                        "table_name": row["table_name"],
+                        "rule_type": row["rule_type"],
+                        "rule": row["rule"],
+                        "column_name": row["column_name"],
+                        "expectation": row["expectation"],
+                        "action_if_failed": row["action_if_failed"],
+                        "enable_for_source_dq_validation": row[
+                            "enable_for_source_dq_validation"
+                        ],
+                        "enable_for_target_dq_validation": row[
+                            "enable_for_target_dq_validation"
+                        ],
+                        "tag": row["tag"],
+                        "description": row["description"],
+                        "enable_error_drop_alert": row["enable_error_drop_alert"],
+                        "error_drop_threshold": row["error_drop_threshold"],
+                    }
 
-                # count the rules enabled for the current run
-                if row["rule_type"] == self._context.get_row_dq_rule_type_name:
-                    self._context.set_num_row_dq_rules()
-                elif row["rule_type"] == self._context.get_agg_dq_rule_type_name:
-                    self._context.set_num_agg_dq_rules(
-                        row["enable_for_source_dq_validation"],
-                        row["enable_for_target_dq_validation"],
-                    )
-                elif row["rule_type"] == self._context.get_query_dq_rule_type_name:
-                    self._context.set_num_query_dq_rules(
-                        row["enable_for_source_dq_validation"],
-                        row["enable_for_target_dq_validation"],
-                    )
+                    if f"{row['rule_type']}_rules" in _expectations:
+                        _expectations[f"{row['rule_type']}_rules"].append(column_map)
+                    else:
+                        _expectations[f"{row['rule_type']}_rules"] = [column_map]
 
-                _expectations["target_table_name"] = target_table
-                _rules_execution_settings = self._get_rules_execution_settings(
-                    _rules_df
-                )
+                    # count the rules enabled for the current run
+                    if row["rule_type"] == self._context.get_row_dq_rule_type_name:
+                        self._context.set_num_row_dq_rules()
+                    elif row["rule_type"] == self._context.get_agg_dq_rule_type_name:
+                        self._context.set_num_agg_dq_rules(
+                            row["enable_for_source_dq_validation"],
+                            row["enable_for_target_dq_validation"],
+                        )
+                    elif row["rule_type"] == self._context.get_query_dq_rule_type_name:
+                        self._context.set_num_query_dq_rules(
+                            row["enable_for_source_dq_validation"],
+                            row["enable_for_target_dq_validation"],
+                        )
+
+                    _expectations["target_table_name"] = target_table
+                    _rules_execution_settings = self._get_rules_execution_settings(
+                        _rules_df
+                    )
             return _expectations, _rules_execution_settings
         except Exception as e:
             raise SparkExpectationsMiscException(

--- a/spark_expectations/utils/reader.py
+++ b/spark_expectations/utils/reader.py
@@ -7,9 +7,7 @@ from pyspark.sql import DataFrame
 from pyspark.sql.functions import col, lit
 from spark_expectations.core.context import SparkExpectationsContext
 from spark_expectations.config.user_config import Constants as user_config
-from spark_expectations.core import get_spark_session
 from spark_expectations.core.exceptions import (
-    SparkExpectationsUserInputOrConfigInvalidException,
     SparkExpectationsMiscException,
 )
 
@@ -24,7 +22,7 @@ class SparkExpectationsReader:
     _context: SparkExpectationsContext
 
     def __post_init__(self) -> None:
-        self.spark = get_spark_session()
+        self.spark = self._context.spark
 
     def set_notification_param(
         self, notification: Optional[Dict[str, Union[int, str, bool]]] = None

--- a/tests/core/test_expectations.py
+++ b/tests/core/test_expectations.py
@@ -2226,7 +2226,7 @@ def test_with_expectations(input_df,
         write_to_table,
         write_to_temp_table,
         row_dq,
-        spark_conf={**spark_conf, **{user_config.se_notifications_on_fail: False}},
+        user_conf={**spark_conf, **{user_config.se_notifications_on_fail: False}},
         options=options,
         options_error_table=options_error_table,
     )
@@ -2349,7 +2349,7 @@ def test_with_expectations_patch(_write_error_stats,
         True,
         agg_dq=None,
         query_dq=None,
-        spark_conf={user_config.se_notifications_on_fail: False},
+        user_conf={user_config.se_notifications_on_fail: False},
         options={'mode': 'overwrite', "format": "delta"},
         options_error_table={'mode': 'overwrite', "format": "delta"}
     )(Mock(return_value=_fixture_df))
@@ -2366,7 +2366,7 @@ def test_with_expectations_dataframe_not_returned_exception(_fixture_create_data
                                                             _fixture_local_kafka_topic):
     partial_func = _fixture_spark_expectations.with_expectations(
         _fixture_expectations,
-        spark_conf={user_config.se_notifications_on_fail: False},
+        user_conf={user_config.se_notifications_on_fail: False},
     )
 
     with pytest.raises(SparkExpectationsMiscException,
@@ -2389,7 +2389,7 @@ def test_with_expectations_exception(_fixture_create_database,
                                      _fixture_local_kafka_topic):
     partial_func = _fixture_spark_expectations.with_expectations(
         _fixture_expectations,
-        spark_conf={user_config.se_notifications_on_fail: False}
+        user_conf={user_config.se_notifications_on_fail: False}
     )
 
     with pytest.raises(SparkExpectationsMiscException,
@@ -2510,7 +2510,7 @@ def test_error_threshold_breach(_mock_notification_hook, _mock_spark_expectation
             user_config.se_final_agg_dq: final_agg_dq,
         },
         query_dq=None,
-        spark_conf={
+        user_conf={
             user_config.se_notifications_on_fail: False,
             user_config.se_notifications_on_error_drop_exceeds_threshold_breach: True,
             user_config.se_notifications_on_error_drop_threshold: 10,
@@ -2654,7 +2654,7 @@ def test_target_table_view_exception(input_df,
             user_config.se_final_query_dq: final_query_dq,
             user_config.se_target_table_view: ""
         },
-        spark_conf={**spark_conf, **{user_config.se_notifications_on_fail: False}},
+        user_conf={**spark_conf, **{user_config.se_notifications_on_fail: False}},
         options=options,
         options_error_table=options_error_table,
     )

--- a/tests/utils/test_reader.py
+++ b/tests/utils/test_reader.py
@@ -222,10 +222,10 @@ def test_get_rules_from_table(mock_context, product_id, table_name,
 
     reader_handler = SparkExpectationsReader(product_id, mock_context)
 
-    expectations, rule_execution_settings = reader_handler.get_rules_from_table("product_rules",
+    expectations, rule_execution_settings = reader_handler.get_rules_from_df("product_rules",
                                                                                 "test_dq_stats_table",
-                                                                                table_name,
-                                                                                action)
+                                                                             table_name,
+                                                                             action)
 
     # Assert
     assert expectations == expected_expectations
@@ -251,4 +251,4 @@ def test_get_rules_dlt_exception(_fixture_reader):
 def test_get_rules_from_table_exception(_fixture_reader):
     with pytest.raises(SparkExpectationsMiscException,
                        match=r"error occurred while retrieving rules list from the table .*"):
-        _fixture_reader.get_rules_from_table("mock_rules_table_1", "mock_dq_stats_table", "table1", ["fail", "drop"])
+        _fixture_reader.get_rules_from_df("mock_rules_table_1", "mock_dq_stats_table", "table1", ["fail", "drop"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As we have already generalized the writer, Now only need for the read from any source to SparkExpectations is for rules table. It will be better if user provides the `rules_df` to the SparkExpectations.

## Description
<!--- Describe your changes in detail -->

1. Replaced `rules_table` with `rules_df`
2. Added examples for delta, iceberg and bigquery

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/spark-expectations/issues/14

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are decentralizing the readers and writers to use native spark functionality, rather  than maintaining in the SparkExpectations

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
