### PR TITLE
fix(ci): trigger PyPI deploy on release published instead of created (#263)

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [ main ]
   release:
-    types: [ created ]
+    types: [ published ]
 
 jobs:
   unittesting:


### PR DESCRIPTION
When a release is first drafted and later published, GitHub fires a
'published' event, not 'created'. The 'published' type covers both
direct publishes and draft-then-publish workflows, ensuring the PyPI
deployment always runs when a release is made available.

https://claude.ai/code/session_01VbETjdy6f8dYs9R7uShtFm