### PR TITLE
docs(metrics): fix typos and fill in querydq_output field descriptions

### DIFF
--- a/docs/configurations/configure_rules.md
+++ b/docs/configurations/configure_rules.md
@@ -74,7 +74,7 @@ action_if_failed, tag, description,  enable_for_source_dq_validation,  enable_fo
 -- The aggregation rule is established on the table count and the metadata of the rule will be captured in the 
 --statistics table when distinct count greater than 10000 and fails the job as "action_if_failed" set to "fail" 
 --and enabled only for validated dataset
-,('apla_nd', '`catalog`.`schema`..customer_order', 'agg_dq', 'row_count', '*', 'count(*)>=10000', 'fail', 'validity',
+,('apla_nd', '`catalog`.`schema`.customer_order', 'agg_dq', 'row_count', '*', 'count(*)>=10000', 'fail', 'validity',
 'distinct ship_mode must be less or equals to 3', false, true, true,false, 0,null, null)
 
 ```

--- a/docs/user_guide/data_quality_metrics.md
+++ b/docs/user_guide/data_quality_metrics.md
@@ -64,7 +64,7 @@ create table if not exists `catalog`.`schema`.`dq_stats` (
 
 ### DQ Detailed Stats Table
 
-Library is responsible for auto generating two stats tables that provide per expectation/rule executaion status view. 
+Library is responsible for auto generating two stats tables that provide per expectation/rule execution status view. 
 
 Tables in question are
 - `<stats_table_name>_detailed`
@@ -156,7 +156,7 @@ dq_job_metadata_info string,  -- (28)!
 !!! warning
     DQ Query Output Table is optional. It is auto created and named as stats table with suffix `_querydq_output`.
 
-    Name can be overriden by passing `querydq_output_custom_table_name`
+    Name can be overridden by passing `querydq_output_custom_table_name`
 
     Default Behaviour: Detailed Stats table is disabled.
 
@@ -185,11 +185,11 @@ create table if not exists `<catalog>`.`<schema>`.`<stats_table_name>_querydq_ou
 
 1. `run_id` Run Id for a specific run 
 2. `product_id` Unique product identifier 
-3. `table_name` --
+3. `table_name` The target table for which the query DQ rule is being evaluated
 4. `rule`  Rule name
 5. `column_name` column name
-6. `alias` --
-7. `dq_type` --
-8. `source_output` --
-9. `target_output` --
+6. `alias` Alias used to identify each sub-query in a query DQ rule
+7. `dq_type` The DQ type (e.g. `query_dq`) this output row was produced by
+8. `source_output` Output of the query DQ rule evaluated against the source dataset
+9. `target_output` Output of the query DQ rule evaluated against the target dataset
 10. `dq_time` Dq executed timestamp


### PR DESCRIPTION
## Summary

Addresses issue #55 with four documentation-only fixes:

1. \`docs/user_guide/data_quality_metrics.md:67\`: \`executaion\` -> \`execution\`.
2. \`docs/user_guide/data_quality_metrics.md:159\`: \`overriden\` -> \`overridden\`.
3. \`docs/configurations/configure_rules.md:77\`: \`\\\`catalog\\\`.\\\`schema\\\`..customer_order\` -> \`\\\`catalog\\\`.\\\`schema\\\`.customer_order\` (double-dot in the qualified table name).
4. \`docs/user_guide/data_quality_metrics.md\` (query DQ output table section): fill in the five fields whose descriptions were just \`--\` (\`table_name\`, \`alias\`, \`dq_type\`, \`source_output\`, \`target_output\`) using wording that matches the surrounding \`_detailed\` table descriptions.

Closes #55

## Testing

Documentation-only change, no code paths altered. Verified the markdown numbering stays consistent and the code-block schema still renders cleanly.